### PR TITLE
fix: updated default_version to latest extension version 1.6.0

### DIFF
--- a/colnames.control
+++ b/colnames.control
@@ -1,6 +1,6 @@
 # colnames extension
 comment = 'Lists the column names in a PostgreSQL RECORD value'
-default_version = '1.1.0'
+default_version = '1.6.0'
 module_pathname = '$libdir/colnames'
 relocatable = true
 


### PR DESCRIPTION
The default_version property in the control file after version 1.1.0 has never been updated anymore!

Signed-off-by: Guilherme Elias <guilherme.elias@gmail.com>